### PR TITLE
Add module for STAC Common Metadata

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,9 @@ AllCops:
   TargetRubyVersion: 3.0
   NewCops: enable
 
+Style/GuardClause:
+  Enabled: false
+
 Style/TrailingCommaInArguments:
   EnforcedStyleForMultiline: consistent_comma
 

--- a/examples/getting_started.rb
+++ b/examples/getting_started.rb
@@ -38,7 +38,7 @@ end
 # ================
 
 # Get an Item by ID.
-item = catalog.find_item('proj-example', recursive: true)
+item = catalog.find_item('CS3-20160503_132131_08')
 
 # Print core Item metadeata.
 puts 'geometry:'
@@ -52,3 +52,8 @@ p item.collection_id
 
 # Get actual Collection instance instead of ID.
 _collection = item.collection
+
+# Print common metadata.
+puts "instruments: #{item.properties.instruments}"
+puts "platform: #{item.properties.platform}"
+puts "gsd: #{item.properties.gsd}"

--- a/lib/stac/asset.rb
+++ b/lib/stac/asset.rb
@@ -1,9 +1,13 @@
 # frozen_string_literal: true
 
+require_relative 'common_metadata'
+
 module STAC
   # Represents \STAC asset object, which contains a link to data associated with an Item or Collection that can be
   # downloaded or streamed.
   class Asset
+    include CommonMetadata
+
     class << self
       # Deserializes an Asset from a Hash.
       def from_hash(hash)
@@ -11,7 +15,7 @@ module STAC
       end
     end
 
-    attr_accessor :href, :title, :description, :type, :roles, :extra
+    attr_accessor :href, :title, :description, :type, :roles
 
     def initialize(href:, title: nil, description: nil, type: nil, roles: nil, **extra)
       @href = href
@@ -19,7 +23,7 @@ module STAC
       @description = description
       @type = type
       @roles = roles
-      @extra = extra.transform_keys(&:to_s)
+      self.extra = extra.transform_keys(&:to_s)
     end
 
     # Serializes self to a Hash.

--- a/lib/stac/common_metadata.rb
+++ b/lib/stac/common_metadata.rb
@@ -1,0 +1,162 @@
+# frozen_string_literal: true
+
+require 'time'
+
+module STAC
+  # Provides read/write methods for \STAC Common Metadata.
+  #
+  # These methods are shorthand accessors of #extra Hash.
+  # Asset and \Item Properties include this module.
+  #
+  # Specification: https://github.com/radiantearth/stac-spec/blob/master/item-spec/common-metadata.md
+  module CommonMetadata
+    attr_accessor :extra
+
+    def title
+      extra['title']
+    end
+
+    def title=(str)
+      extra['title'] = str
+    end
+
+    def description
+      extra['description']
+    end
+
+    def description=(str)
+      extra['description'] = str
+    end
+
+    def created
+      if (str = extra['created'])
+        Time.iso8601(str)
+      end
+    end
+
+    def created=(time)
+      extra['created'] = case time
+                         when Time
+                           time.iso8601
+                         else
+                           time
+                         end
+    end
+
+    def updated
+      if (str = extra['updated'])
+        Time.iso8601(str)
+      end
+    end
+
+    def updated=(time)
+      extra['updated'] = case time
+                         when Time
+                           time.iso8601
+                         else
+                           time
+                         end
+    end
+
+    def start_datetime
+      if (str = extra['start_datetime'])
+        Time.iso8601(str)
+      end
+    end
+
+    def start_datetime=(time)
+      extra['start_datetime'] = case time
+                                when Time
+                                  time.iso8601
+                                else
+                                  time
+                                end
+    end
+
+    def end_datetime
+      if (str = extra['end_datetime'])
+        Time.iso8601(str)
+      end
+    end
+
+    def end_datetime=(time)
+      extra['end_datetime'] = case time
+                              when Time
+                                time.iso8601
+                              else
+                                time
+                              end
+    end
+
+    # Returns a range from #start_datetime to #end_datetime.
+    def datetime_range
+      if (start = start_datetime) && (last = end_datetime)
+        start..last
+      end
+    end
+
+    # Sets #start_datetime and #end_datetime by the given range.
+    def datetime_range=(time_range)
+      self.start_datetime = time_range.begin
+      self.end_datetime = time_range.end
+    end
+
+    def license
+      extra['license']
+    end
+
+    def license=(str)
+      extra['license'] = str
+    end
+
+    def providers
+      extra.fetch('providers', []).map do |provider_hash|
+        Provider.from_hash(provider_hash)
+      end
+    end
+
+    def providers=(arr)
+      extra['providers'] = arr.map(&:to_h)
+    end
+
+    def platform
+      extra['platform']
+    end
+
+    def platform=(str)
+      extra['platform'] = str
+    end
+
+    def instruments
+      extra['instruments']
+    end
+
+    def instruments=(arr)
+      extra['instruments'] = arr
+    end
+
+    def constellation
+      extra['constellation']
+    end
+
+    def constellation=(str)
+      extra['constellation'] = str
+    end
+
+    def mission
+      extra['mission']
+    end
+
+    def mission=(str)
+      extra['mission'] = str
+    end
+
+    def gsd
+      extra['gsd']
+    end
+
+    def gsd=(num)
+      extra['gsd'] = num
+    end
+  end
+end

--- a/lib/stac/properties.rb
+++ b/lib/stac/properties.rb
@@ -1,12 +1,15 @@
 # frozen_string_literal: true
 
 require 'time'
+require_relative 'common_metadata'
 
 module STAC
   # Represents \STAC properties object, which is additional metadata for Item.
   #
   # Specification: https://github.com/radiantearth/stac-spec/blob/master/item-spec/item-spec.md#properties-object
   class Properties
+    include CommonMetadata
+
     class << self
       # Deserializes a Properties from a Hash.
       def from_hash(hash)
@@ -16,11 +19,11 @@ module STAC
       end
     end
 
-    attr_accessor :datetime, :extra
+    attr_accessor :datetime
 
     def initialize(datetime:, **extra)
       @datetime = datetime
-      @extra = extra.transform_keys(&:to_s)
+      self.extra = extra.transform_keys(&:to_s)
     end
 
     # Serializes self to a Hash.

--- a/sig/stac/asset.rbs
+++ b/sig/stac/asset.rbs
@@ -1,5 +1,7 @@
 module STAC
   class Asset
+    include CommonMetadata
+
     def self.from_hash: (Hash[String, untyped] hash) -> Asset
 
     attr_accessor href: String

--- a/sig/stac/common_metadata.rbs
+++ b/sig/stac/common_metadata.rbs
@@ -1,0 +1,34 @@
+module STAC
+  module CommonMetadata
+    attr_accessor extra: Hash[String, untyped]
+    
+    def title: -> String?
+    def title=: (String) -> void
+    def description: -> String?
+    def description=: (String) -> void
+    def created: -> Time?
+    def created=: (Time | String) -> void
+    def updated: -> Time?
+    def updated=: (Time | String) -> void
+    def start_datetime: -> Time?
+    def start_datetime=: (Time | String) -> void
+    def end_datetime: -> Time?
+    def end_datetime=: (Time | String) -> void
+    def datetime_range: -> Range[Time]?
+    def datetime_range=: (Range[Time]) -> void
+    def license: -> String?
+    def license=: (String) -> void
+    def providers: -> Array[Provider]
+    def providers=: (Array[Provider]) -> void
+    def platform: -> String?
+    def platform=: (String) -> void
+    def instruments: -> Array[String]?
+    def instruments=: (Array[String]) -> void
+    def constellation: -> String?
+    def constellation=: (String) -> void
+    def mission: -> String?
+    def mission=: (String) -> void
+    def gsd: -> Numeric
+    def gsd=: (Numeric) -> void
+  end
+end

--- a/sig/stac/properties.rbs
+++ b/sig/stac/properties.rbs
@@ -1,5 +1,7 @@
 module STAC
   class Properties
+    include CommonMetadata
+
     def self.from_hash: (Hash[String, untyped] hash) -> Properties
 
     attr_accessor datetime: Time?


### PR DESCRIPTION
Add module `STAC::CommonMedatada`.
This module has read/write methods for [STAC Common Metadata](https://github.com/radiantearth/stac-spec/blob/master/item-spec/common-metadata.md) fields.
`Asset` and `Properties` include this module based on the specification.