### PR TITLE
Make `http_client` instance variable of `STACObject`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased]
 
 - Add `STAC::CommonMetadata` and make `Asset` and `Properties` include it.
+- Make `http_client` instance variable of `STACObject` instead of class instance variable of `ObjectResolver`.
 
 ## [0.1.0] - 2022-10-09
 

--- a/lib/stac.rb
+++ b/lib/stac.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require_relative 'stac/default_http_client'
 require_relative 'stac/object_resolver'
 require_relative 'stac/version'
 
@@ -16,8 +17,8 @@ module STAC
     # Returns a \STAC object resolved from the given URL.
     #
     # When the resolved object does not have rel="self" link, adds a rel="self" link with the give url.
-    def from_url(url, resolver: ObjectResolver.new)
-      object = resolver.resolve(url)
+    def from_url(url, http_client: DefaultHTTPClient.new)
+      object = ObjectResolver.new(http_client: http_client).resolve(url)
       object.self_href = url unless object.self_href
       object
     end

--- a/lib/stac/link.rb
+++ b/lib/stac/link.rb
@@ -2,6 +2,7 @@
 
 require 'pathname'
 require 'uri'
+require_relative 'default_http_client'
 require_relative 'errors'
 
 module STAC
@@ -53,18 +54,12 @@ module STAC
     # Returns a \STAC object resolved from HREF.
     #
     # When it could not assemble the absolute HREF, it returns nil.
-    def target
+    def target(http_client: owner&.http_client || DefaultHTTPClient.new)
       @target ||= if (url = absolute_href)
-                    object = resolver.resolve(url)
+                    object = ObjectResolver.new(http_client: http_client).resolve(url)
                     object.self_href = url
                     object
                   end
-    end
-
-    private
-
-    def resolver
-      @resolver ||= ObjectResolver.new
     end
   end
 end

--- a/lib/stac/stac_object.rb
+++ b/lib/stac/stac_object.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'json'
+require_relative 'default_http_client'
 require_relative 'errors'
 require_relative 'link'
 require_relative 'spec_version'
@@ -27,6 +28,9 @@ module STAC
 
     attr_accessor :id, :stac_extensions, :extra
 
+    # HTTP Client to fetch objects from HTTP HREF links.
+    attr_accessor :http_client
+
     attr_reader :links
 
     def initialize(id:, links:, stac_extensions: nil, **extra)
@@ -37,6 +41,7 @@ module STAC
       end
       @stac_extensions = stac_extensions
       @extra = extra.transform_keys(&:to_s)
+      @http_client = DefaultHTTPClient.new
     end
 
     def type

--- a/sig/stac.rbs
+++ b/sig/stac.rbs
@@ -1,5 +1,5 @@
 # See the writing guide of rbs: https://github.com/ruby/rbs#guides
 module STAC
   def self.from_file: (String path) -> (Catalog | Collection | Item)
-  %a{rbs:test:skip} def self.from_url: (String url, ?resolver: ObjectResolver) -> (Catalog | Collection | Item)
+  %a{rbs:test:skip} def self.from_url: (String url, ?http_client: _HTTPClient) -> (Catalog | Collection | Item)
 end

--- a/sig/stac/default_http_client.rbs
+++ b/sig/stac/default_http_client.rbs
@@ -6,4 +6,8 @@ module STAC
 
     def get: (URI uri) -> String
   end
+
+  interface _HTTPClient
+    def get: (URI uri) -> String
+  end
 end

--- a/sig/stac/link.rbs
+++ b/sig/stac/link.rbs
@@ -8,6 +8,7 @@ module STAC
     attr_accessor title: String?
     attr_accessor extra: Hash[String, untyped]
     attr_accessor owner: STACObject | nil
+    attr_accessor http_client: _HTTPClient
     @target: Catalog | Collection | Item | nil
     @resolver: ObjectResolver
 
@@ -15,7 +16,7 @@ module STAC
 
     def to_h: -> Hash[String, untyped]
     def absolute_href: -> String?
-    def target: -> (Catalog | Collection | Item | nil)
+    def target: (?http_client: _HTTPClient) -> (Catalog | Collection | Item | nil)
 
     private
 

--- a/sig/stac/object_resolver.rbs
+++ b/sig/stac/object_resolver.rbs
@@ -2,13 +2,13 @@ module STAC
   class ObjectResolver
     RESOLVABLES: Array[_STACObjectClass]
 
-    attr_writer self.default_http_client: _HTTPClient
+    attr_accessor self.resolvables: Array[_STACObjectClass]
 
     def self.default_http_client: -> _HTTPClient
 
     attr_reader http_client: _HTTPClient
 
-    def initialize: (?http_client: _HTTPClient) -> void
+    def initialize: (http_client: _HTTPClient) -> void
 
     def resolve: (String url) -> (Catalog | Collection | Item)
 
@@ -20,9 +20,5 @@ module STAC
   interface _STACObjectClass
     def type: -> String
     def from_hash: (Hash[String, untyped] hash) -> (Catalog | Collection | Item)
-  end
-
-  interface _HTTPClient
-    def get: (URI uri) -> String
   end
 end

--- a/sig/stac/stac_object.rbs
+++ b/sig/stac/stac_object.rbs
@@ -7,6 +7,7 @@ module STAC
     attr_accessor id: String
     attr_accessor stac_extensions: Array[String]?
     attr_accessor extra: Hash[String, untyped]
+    attr_accessor http_client: _HTTPClient
     attr_reader links: Array[Link]
 
     def initialize: (


### PR DESCRIPTION
### Problem

The default HTTP client is set on class instance variable of `ObjectResolver`.
Therefore, it is impossible to change HTTP client for each STAC object instance.

### Solution

Set `http_client` as instance variable of `STACObject`.